### PR TITLE
ConfigurableService 인터페이스 구현 (페이지 모델 기초 설정)

### DIFF
--- a/teamcostco/src/main/java/com/ezentwix/teamcostco/controller/IndexController.java
+++ b/teamcostco/src/main/java/com/ezentwix/teamcostco/controller/IndexController.java
@@ -16,7 +16,7 @@ public class IndexController {
     @GetMapping("/")
     public String showIndex(Model model) {
         // DashBoard를 메인으로 둡니다.
-        dashBoardService.configureDashboardData(model);
+        dashBoardService.configureModel(model);
         return "index";
     }
 }

--- a/teamcostco/src/main/java/com/ezentwix/teamcostco/controller/dashboard/DashBoardController.java
+++ b/teamcostco/src/main/java/com/ezentwix/teamcostco/controller/dashboard/DashBoardController.java
@@ -15,8 +15,7 @@ public class DashBoardController {
 
     @GetMapping("/dashboard")
     public String showDashboard(Model model) {
-        // dashboard 페이지에서 사용할 데이터를 추가합니다
-        dashBoardService.configureDashboardData(model);
+        dashBoardService.configureModel(model);
         return "index";
     }
 }

--- a/teamcostco/src/main/java/com/ezentwix/teamcostco/service/ConfigurableService.java
+++ b/teamcostco/src/main/java/com/ezentwix/teamcostco/service/ConfigurableService.java
@@ -1,0 +1,29 @@
+package com.ezentwix.teamcostco.service;
+
+import java.util.List;
+
+import org.springframework.ui.Model;
+
+public interface ConfigurableService {
+    String getUri();
+    String getPageTitle();
+    
+    default List<String> getCssFiles() {
+        return null;
+    }
+
+    default List<String> getJsFiles() {
+        return null;
+    }
+
+    default void configureModel(Model model) {
+        model.addAttribute("uri", getUri());
+        model.addAttribute("pageTitle", getPageTitle());
+
+        // CSS 파일 목록 설정
+        model.addAttribute("cssFiles", getCssFiles());
+
+        // JS 파일 목록 설정
+        model.addAttribute("jsFiles", getJsFiles());
+    }
+}

--- a/teamcostco/src/main/java/com/ezentwix/teamcostco/service/dashboard/DashBoardService.java
+++ b/teamcostco/src/main/java/com/ezentwix/teamcostco/service/dashboard/DashBoardService.java
@@ -3,24 +3,35 @@ package com.ezentwix.teamcostco.service.dashboard;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
-import org.springframework.ui.Model;
 
-import com.ezentwix.teamcostco.dto.ProductDTO;
-import com.ezentwix.teamcostco.service.products.ProductService;
+import com.ezentwix.teamcostco.service.ConfigurableService;
 
 import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
-public class DashBoardService {
-    private final ProductService productsService;
+public class DashBoardService implements ConfigurableService{
 
-    public void configureDashboardData(Model model) {
-        model.addAttribute("uri", "dashboard/dashboard");
-        model.addAttribute("pageTitle", "대시보드");
+    @Override
+    public String getUri() {
+        return "dashboard/dashboard";
+    }
 
-        model.addAttribute("cssFiles",
-                List.of("/css/dashboard/styles.css"));
-        // model.addAttribute("jsFiles", null);
+    @Override
+    public String getPageTitle() {
+        return "대시보드";
+    }
+
+    // 아래 두 메서드(getCssFiles, getJsFiles)는
+    // Override 메서드를 구현하지않으면 null을 반환하도록 설계되어있음
+
+    @Override
+    public List<String> getCssFiles() {
+        return List.of("/css/dashboard/styles.css");
+    }
+    
+    @Override
+    public List<String> getJsFiles() {
+        return null;
     }
 }

--- a/teamcostco/src/main/resources/static/css/common/styles.css
+++ b/teamcostco/src/main/resources/static/css/common/styles.css
@@ -21,6 +21,7 @@ body {
 main {
     flex: 1;
     padding: 20px;
+    overflow-y: scroll;
 }
 
 .page-title {


### PR DESCRIPTION
**ConfigurableService 인터페이스는 페이지에 제공되는 모델 설정을 위한 기본 메서드를 정의함**

**getUri()**
URI 문자열을 반환해야 하는 메서드
페이지의 경로를 설정함

**getPageTitle():**
페이지 제목을 문자열로 반환해야 하는 메서드
타이틀을 설정함

**getCssFiles():**
CSS 파일 경로의 리스트를 반환하는 메서드
기본적으로 null을 반환하며 오버라이드하여 특정 CSS 파일 경로를 설정할 수 있음

**getJsFiles():**
JS 파일 경로의 리스트를 반환하는 메서드
기본적으로 null을 반환하며, 오버라이드하여 특정 JS 파일 경로를 설정할 수 있음

**configureModel(Model model):**
모델에 URI, 페이지 제목, CSS 파일 목록, JS 파일 목록을 설정하는 메서드
**기본구현**을 제공하며, 모델에 필요한 설정 값을 추가할 수 있음

**기본 구현**
**getUri**와 **getPageTitle** 의무적으로 구현해야함
**getCssFiles()**와 **getJsFiles()** 메서드는 기본적으로 null을 반환함
필요에 따라 이 메서드들을 오버라이드하여 원하는 CSS 파일과 JS 파일을 지정할 수 있음